### PR TITLE
Chore: Update App.test.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import './App.css';
 import { gql, useQuery } from '@apollo/client';
 import StepZenLogo from './light-blue.svg';
-const GET_QUERY = gql`
+export const GET_QUERY = gql`
   query MyQuery   {
     capsule(id: "C105") {
       id

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,70 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, cleanup } from '@testing-library/react';
+import App, { GET_QUERY } from './App';
+import { MockedProvider } from '@apollo/client/testing';
+import { act } from 'react-dom/test-utils';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+afterEach(cleanup);
+
+const dataFixture = {
+  capsule: {
+    id: '1',
+    landings: 0,
+    original_launch: {},
+    reuse_count: 0,
+    missions: [
+      {
+        flight: 0,
+        name: 'test-capsule-mission-name',
+      },
+    ],
+  },
+};
+
+const errorMock = {
+  request: {
+    query: GET_QUERY,
+  },
+  error: new Error('A test error occurred'),
+};
+
+const validMock = {
+  request: {
+    query: GET_QUERY,
+  },
+  result: {
+    data: dataFixture,
+  },
+};
+
+test('renders loading screen', () => {
+  const { asFragment } = render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <App />
+    </MockedProvider>
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders error screen', async () => {
+  const { asFragment } = render(
+    <MockedProvider mocks={[errorMock]} addTypename={false}>
+      <App />
+    </MockedProvider>
+  );
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders app screen', async () => {
+  const { asFragment } = render(
+    <MockedProvider mocks={[validMock]} addTypename={false}>
+      <App />
+    </MockedProvider>
+  );
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders app screen 1`] = `
+<DocumentFragment>
+  <div
+    class="App"
+  >
+    <header
+      class="App-header"
+    >
+      <img
+        alt="StepZen Logo"
+        src="light-blue.svg"
+        width="200px"
+      />
+      <p
+        style="margin-top: 40px;"
+      >
+        Capsule information pulled from StepZen Endpoint:
+      </p>
+      <p />
+      <ul>
+        <li>
+          id: 1
+        </li>
+        <li>
+          landings: 0
+        </li>
+        <li>
+          reuse-count: 0
+        </li>
+      </ul>
+      <p />
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`renders error screen 1`] = `
+<DocumentFragment>
+  <pre>
+    {
+  "graphQLErrors": [],
+  "networkError": {},
+  "message": "A test error occurred"
+}
+  </pre>
+</DocumentFragment>
+`;
+
+exports[`renders loading screen 1`] = `
+<DocumentFragment>
+  <p>
+    Loading ...
+  </p>
+</DocumentFragment>
+`;


### PR DESCRIPTION
# Linked Issue

#4 

# Description

Updates `App.test.js` to test the various render states of `App.js`.

As a small aside, some thought might want to be given to that component's layout as the following warning is printed to the console when `yarn test` is run:

```sh
...
  console.error
    Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>.
        at ul
        at p
        at header
        at div
        at App (/foo/stepzen-spacex-graphql/src/App.js:21:36)
        at ApolloProvider (/foo/stepzen-spacex-graphql/node_modules/@apollo/client/react/context/ApolloProvider.js:5:21)
        at MockedProvider (/foo/stepzen-spacex-graphql/node_modules/@apollo/client/utilities/testing/mocking/MockedProvider.js:10:28)

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at validateDOMNesting (node_modules/react-dom/cjs/react-dom.development.js:10083:7)
      at createInstance (node_modules/react-dom/cjs/react-dom.development.js:10181:5)
      at completeWork (node_modules/react-dom/cjs/react-dom.development.js:19464:28)
      at completeUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22812:16)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22787:5)
...
```

A super simple fix for it is to remove lines [35](https://github.com/stepzen-samples/stepzen-spacex-graphql/blob/main/src/App.js#L35), and [41](https://github.com/stepzen-samples/stepzen-spacex-graphql/blob/main/src/App.js#L41).

I smoke tested it and that element's removal has no visual effect. Happy to open a follow up PR to do this, if that is the desired path forward.

# Methodology

* https://www.apollographql.com/docs/react/development-testing/testing/
* https://jestjs.io/docs/snapshot-testing