### PR TITLE
add debugging type to graphql

### DIFF
--- a/graphql/api_spacex_land.graphql
+++ b/graphql/api_spacex_land.graphql
@@ -1358,3 +1358,19 @@ type CoreMission {
   name: String
   flight: Int
 }
+
+type debug {
+  args: JSON
+  data: JSON
+  files: JSON
+  form: JSON
+  headers: JSON
+  json: JSON
+  method: String
+  url: String
+}
+
+type Query {
+  debugger(id: String!): debug
+    @rest(endpoint: "https://httpbin.org/anything/$id")
+}


### PR DESCRIPTION
#9 

# Description
Added a debugging type into the api_spacex_land.graphql. 
# Methodology
Adding a debugging type to help users see what's being sent, with a call to httpbin.org, for error handling. 
