### PR TITLE
Graphql query docs

### DIFF
--- a/graphql/api_spacex_land.graphql
+++ b/graphql/api_spacex_land.graphql
@@ -1224,7 +1224,7 @@ type Location {
 }
 
 """
-fields for  finding information on all launches
+fields for finding information on all launches
 """
 input LaunchFind {
   apoapsis_km: Float


### PR DESCRIPTION
# Linked Issue
#10 
# Description
This PR completes the addition of doc strings to the GraphQL queries for the StepZen SpaceX React App.
# Methodology
Previously, the docs for the GraphQL queries were incomplete. Thus, doc strings were added for remaining queries, as well inputs/types that had no docs. At the opening of this PR, changes were correctly rendering on the app.
